### PR TITLE
Add query_error_to_string

### DIFF
--- a/src/gleam/pgo.gleam
+++ b/src/gleam/pgo.gleam
@@ -3,6 +3,7 @@
 //// Gleam wrapper around pgo library
 
 import gleam/dynamic.{type DecodeErrors, type Decoder, type Dynamic}
+import gleam/int
 import gleam/list
 import gleam/option.{type Option, None, Some}
 import gleam/result
@@ -226,6 +227,22 @@ pub type QueryError {
   /// No connection was available to execute the query. This may be due to
   /// invalid connection details such as an invalid username or password.
   ConnectionUnavailable
+}
+
+pub fn query_error_to_string(error: QueryError) -> String {
+  case error {
+    ConstraintViolated(message, _constraint, _detail) -> message
+    PostgresqlError(_code, _name, message) -> message
+    UnexpectedArgumentCount(expected, got) ->
+      "Unexpected argument count, expected "
+      <> int.to_string(expected)
+      <> " but got "
+      <> int.to_string(got)
+    UnexpectedArgumentType(expected, got) ->
+      "Unexpected argument type, expected " <> expected <> " but got " <> got
+    UnexpectedResultType(_errors) -> "Failed to decode"
+    ConnectionUnavailable -> "Connection unavailable"
+  }
 }
 
 /// Run a query against a PostgreSQL database.

--- a/test/gleam/pgo_test.gleam
+++ b/test/gleam/pgo_test.gleam
@@ -470,3 +470,8 @@ pub fn transaction_commit_test() {
 
   pgo.disconnect(db)
 }
+
+pub fn query_error_to_string_test() {
+  pgo.query_error_to_string(pgo.UnexpectedArgumentCount(2, 1))
+  |> should.equal("Unexpected argument count, expected 2 but got 1")
+}


### PR DESCRIPTION
I would like to have a quick way to convert the query errors to a string

```gleam
fn find_user(email: String) ->  Result(User, String) {
  ...

  use returned <- result.try(
    pgo.execute(select_sql, db, [pgo.text(email)], return_type)
    |> result.map_error(pgo.query_error_to_string),
  )

  ...
}
```

What do you think?
Would be nice if `dynamic` could have this too
