### PR TITLE
replace old gleam_pgo references with pog

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ import gleeunit/should
 pub fn main() {
   // Start a database connection pool.
   // Typically you will want to create one pool for use in your program
-  let db = 
+  let db =
     pog.default_config()
     |> pog.host("localhost")
     |> pog.database("my_database")
@@ -38,7 +38,7 @@ pub fn main() {
 
   // Run the query against the PostgreSQL database
   // The int `1` is given as a parameter
-  let assert Ok(response) = 
+  let assert Ok(response) =
     pog.query(sql_query)
     |> pog.parameter(pog.int(1))
     |> pog.returning(row_decoder)
@@ -57,17 +57,17 @@ pub fn main() {
 ## Installation
 
 ```sh
-gleam add gleam_pgo
+gleam add pog
 ```
 
 ## Support of connection URI
 
-Configuring a Postgres connection is done by using `Config` type in `gleam/pgo`.
+Configuring a Postgres connection is done by using `Config` type in `pog`.
 To facilitate connection, and to provide easy integration with the rest of the
-Postgres ecosystem, `gleam_pgo` provides handling of
+Postgres ecosystem, `pog` provides handling of
 [connection URI as defined by Postgres](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING-URIS).
 Shape of connection URI is `postgresql://[username:password@][host:port][/dbname][?query]`.
-Call `gleam/pgo.url_config` with your connection URI, and in case it's correct
+Call `pog.url_config` with your connection URI, and in case it's correct
 against the Postgres standard, your `Config` will be automatically generated!
 
 Here's an example, using [`envoy`](https://github.com/lpil/envoy) to read the
@@ -75,15 +75,15 @@ connection URI from the environment.
 
 ```gleam
 import envoy
-import gleam/pgo
+import pog
 
 /// Read the DATABASE_URL environment variable.
-/// Generate the pgo.Config from that database URL.
+/// Generate the pog.Config from that database URL.
 /// Finally, connect to database.
-pub fn read_connection_uri() -> Result(pgo.Connection, Nil) {
+pub fn read_connection_uri() -> Result(pog.Connection, Nil) {
   use database_url <- result.try(envoy.get("DATABASE_URL"))
-  use config <- result.try(pgo.url_config(database_url))
-  Ok(pgo.connect(config))
+  use config <- result.try(pog.url_config(database_url))
+  Ok(pog.connect(config))
 }
 ```
 
@@ -92,7 +92,7 @@ pub fn read_connection_uri() -> Result(pgo.Connection, Nil) {
 In Postgres, you can define a type `json` or `jsonb`. Such a type can be query
 in SQL, but Postgres returns it a simple string, and accepts it as a simple string!
 When writing or reading a JSON, you can simply use
-`pgo.text(json.to_string(my_json))` and `dynamic.string` to respectively write
+`pog.text(json.to_string(my_json))` and `dynamic.string` to respectively write
 and read them!
 
 ## Rows as maps
@@ -103,7 +103,7 @@ Once activated, every returned rows will take the form of a `Dict`.
 
 ## Atom generation
 
-Creating a connection pool with the `pgo.connect` function dynamically generates
+Creating a connection pool with the `pog.connect` function dynamically generates
 an Erlang atom. Atoms are not garbage collected and only a certain number of
 them can exist in an Erlang VM instance, and hitting this limit will result in
 the VM crashing. Due to this limitation you should not dynamically open new

--- a/src/pog.gleam
+++ b/src/pog.gleam
@@ -2,7 +2,7 @@
 ////
 //// Gleam wrapper around pgo library
 
-// TODO: add time and timestamp with zone once PGO supports them
+// TODO: add time and timestamp with zone once pgo supports them
 
 import gleam/dynamic.{type DecodeErrors, type Decoder, type Dynamic}
 import gleam/float
@@ -51,7 +51,7 @@ pub type Config {
     trace: Bool,
     /// (default: Ipv4) Which internet protocol to use for this connection
     ip_version: IpVersion,
-    /// (default: False) By default, PGO will return a n-tuple, in the order of the query.
+    /// (default: False) By default, pgo will return a n-tuple, in the order of the query.
     /// By setting `rows_as_map` to `True`, the result will be `Dict`.
     rows_as_map: Bool,
   )
@@ -155,7 +155,7 @@ pub fn ip_version(config: Config, ip_version: IpVersion) -> Config {
   Config(..config, ip_version:)
 }
 
-/// By default, PGO will return a n-tuple, in the order of the query.
+/// By default, pgo will return a n-tuple, in the order of the query.
 /// By setting `rows_as_map` to `True`, the result will be `Dict`.
 pub fn rows_as_map(config: Config, rows_as_map: Bool) -> Config {
   Config(..config, rows_as_map:)


### PR DESCRIPTION
There were some places left where the documentation referred to gleam_pgo, I've changed it so it's always referring to pog