### PR TITLE
Fix `array` signature `fn (List(a)) -> Value` to `fn (List(a), fn (a) -> Value) -> Value`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.0.1 - Unreleased
+
+- Fix `array` signature.
+
 ## v1.0.0 - 2024-11-11
 
 - Renamed to `pog`.

--- a/src/pog.gleam
+++ b/src/pog.gleam
@@ -273,8 +273,10 @@ pub fn text(a: String) -> Value
 @external(erlang, "pog_ffi", "coerce")
 pub fn bytea(a: BitArray) -> Value
 
-@external(erlang, "pog_ffi", "coerce")
-pub fn array(a: List(a)) -> Value
+pub fn array(a: List(a), mapper: fn(a) -> Value) -> Value {
+  list.map(a, mapper)
+  |> coerce_value
+}
 
 pub fn timestamp(timestamp: Timestamp) -> Value {
   coerce_value(#(date(timestamp.date), time(timestamp.time)))

--- a/test/pog_test.gleam
+++ b/test/pog_test.gleam
@@ -355,9 +355,14 @@ pub fn bytea_test() {
 pub fn array_test() {
   let decoder = dynamic.list(dynamic.string)
   start_default()
-  |> assert_roundtrip(["black"], "text[]", pog.array, decoder)
-  |> assert_roundtrip(["gray"], "text[]", pog.array, decoder)
-  |> assert_roundtrip(["gray", "black"], "text[]", pog.array, decoder)
+  |> assert_roundtrip(["black"], "text[]", pog.array(_, pog.text), decoder)
+  |> assert_roundtrip(["gray"], "text[]", pog.array(_, pog.text), decoder)
+  |> assert_roundtrip(
+    ["gray", "black"],
+    "text[]",
+    pog.array(_, pog.text),
+    decoder,
+  )
   |> pog.disconnect
 }
 


### PR DESCRIPTION
`pog.array` was wrong, in the sense that any data could be sent in the parameter. That PR come to fix this.
To stay consistent with packages like `json`, I decided to provide the converter function as argument of `array`. We could introduce `preprocessed_array` if you think it's useful.