### PR TITLE
Added configurable and extendable ssl options

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,22 @@ pub fn connect() {
 }
 ```
 
+### SSL Options
+`pog` also provides additional SSL configuration options through SslOptions. Currently, you can configure:
+- `sni_enabled`: Enable or disable Server Name Indication (SNI). By default, this is set to True and uses the connection hostname.
+```gleam
+import pog
+
+pub fn connect() {
+  pog.default_config()
+  |> pog.ssl(pog.SslVerified)
+  |> pog.ssl_options(pog.SslOptions(sni_enabled: True))
+  |> pog.connect
+}
+```
+When SNI is enabled, it helps ensure proper SSL certificate verification by sending the server name during the SSL handshake. This is particularly important when connecting to databases that use virtual hosting or when the database certificate includes multiple domain names.
+The default configuration (sni_enabled: True) is recommended for most use cases as it provides the most secure and reliable SSL connection setup.
+
 ### Need some help?
 
 You tried to setup a secured connection, but it does not work? Your container

--- a/src/pog.gleam
+++ b/src/pog.gleam
@@ -32,6 +32,8 @@ pub type Config {
     password: Option(String),
     /// (default: SslDisabled): Whether to use SSL or not.
     ssl: Ssl,
+    /// - information to be added here
+    ssl_options: SslOptions,
     /// (default: []): List of 2-tuples, where key and value must be binary
     /// strings. You can include any Postgres connection parameter here, such as
     /// `#("application_name", "myappname")` and `#("timezone", "GMT")`.
@@ -82,6 +84,19 @@ pub type Ssl {
   SslDisabled
 }
 
+pub type SslOptions {
+    /// Additional SSL configuration options for fine-tuning the SSL connection.
+    /// Currently supports Server Name Indication (SNI) configuration:
+    /// - `sni_enabled`: When set to `True` (default), enables SNI using the connection
+    /// hostname. SNI helps ensure proper SSL certificate verification by sending
+    /// the server name during the SSL handshake. This is particularly important
+    /// when connecting to databases that use virtual hosting or when the database
+    /// certificate includes multiple domain names.
+    SslOptions(
+        sni_enabled: Bool
+    )
+}
+
 /// Database server hostname.
 ///
 /// (default: 127.0.0.1)
@@ -116,6 +131,13 @@ pub fn password(config: Config, password: Option(String)) -> Config {
 /// (default: False)
 pub fn ssl(config: Config, ssl: Ssl) -> Config {
   Config(..config, ssl:)
+}
+
+/// Ssl options you'd like to change
+///
+/// (default: SslOptions(sni_enabled: True))
+pub fn ssl_options(config: Config, ssl_options: SslOptions) -> Config {
+    Config(..config, ssl_options:)
 }
 
 /// Any Postgres connection parameter here, such as
@@ -212,6 +234,7 @@ pub fn default_config() -> Config {
     user: "postgres",
     password: None,
     ssl: SslDisabled,
+    ssl_options: SslOptions(sni_enabled: True),
     connection_parameters: [],
     pool_size: 10,
     queue_target: 50,


### PR DESCRIPTION
# Add SSL Options support

This PR adds support for configuring SSL options in `pog`, starting with Server Name Indication (SNI) support. 
As mentioned: #51 

## Changes

- Added new `SslOptions` type to handle SSL-specific configurations
- Implemented SNI support with an `sni_enabled` flag (default: `True`)
- Added `ssl_options` function to configure SSL options
- Updated documentation with SSL options usage and examples
- Refactored SSL handling in the Erlang FFI to support configurable options

## Example

```gleam
import pog

pub fn connect() {
  pog.default_config()
  |> pog.ssl(pog.SslVerified)
  |> pog.ssl_options(pog.SslOptions(sni_enabled: True))
  |> pog.connect
}
```
The changes improve SSL connection handling by making it more configurable and secure by default, particularly for scenarios involving virtual hosting or multi-domain SSL certificates.


Note to author:
Please let me know if this makes sense to you or you'd like to see it differently. I thought this could be an extendable way of adding options.
I'm very much a beginner of gleam or functional languages in general.
I have 0 experience with erlang. So keep this in mind if you have comments.
Ran all tests succesfully with `gleam test`. However there are currently no tests for anything Ssl related.