### PR TITLE
chore: fix result.then deprecation warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Updated `result.then` to `result.try` to resolve deprecation warnings.
+
 ## v3.2.0 - 2025-01-16
 
 - The `url_config` function now defaults to port (5432) when port is not specified.


### PR DESCRIPTION
Updated `result.then` to `result.try` to resolve recent deprecation warnings.