### PR TITLE
Add Range type, encoder and decoder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v4.2.0 - TODO
+
+- Added `Range`, `Bound` and `Inclusivity` types to represent PostgreSQL range types
+- Added `range_decoder` and `range` functions to decode and encode ranges
+
 ## v4.1.0 - 2025-07-14
 
 - Added a `numeric_decoder` to decode numeric types coming from postgres.

--- a/test/README.md
+++ b/test/README.md
@@ -8,6 +8,7 @@ Initialize a Postgres Database, and use as environment variables:
 export PGUSER="postgres"
 export PGHOST="localhost"
 export PGPASSWORD="postgres"
+export PGUSER="postgres"
 export PGPORT=5432
 ```
 


### PR DESCRIPTION
This PR introduces a generic `Range(t)` type to support [Postgres range types](https://www.postgresql.org/docs/current/rangetypes.html).
Please let me know if there's anything I can improve.