### PR TITLE
Respect the DecodeOpts inside a transaction

### DIFF
--- a/src/pog_ffi.erl
+++ b/src/pog_ffi.erl
@@ -85,7 +85,8 @@ start(Config) ->
 query(Pool, Sql, Arguments, Timeout) ->
     Res = case Pool of
         {single_connection, Conn} ->
-            pgo_handler:extended_query(Conn, Sql, Arguments, #{});
+              DecodeOpts = element(11, Conn),
+              pgo_handler:extended_query(Conn, Sql, Arguments, DecodeOpts, #{});
         {pool, Name} ->
             Options = #{
                 pool => Name,


### PR DESCRIPTION
The decode options were not passed through to the `pgo_handler:extended_query` call, which cause queries done inside a transaction or the transaction call itself not to respect the `rows_as_maps` setting.

I have 0 experience in Erlang and don't know how to do this. Please feel free to correct me if I'm doing something silly. 
Basically trying to pass down the `DecodeOpts` from the `Conn` down to the `extended_query` call.

fixes #69 